### PR TITLE
:bug: Fix gc artifact for multi-arch manifest

### DIFF
--- a/pkg/dal/dao/artifact.go
+++ b/pkg/dal/dao/artifact.go
@@ -121,10 +121,10 @@ func (s *artifactService) Create(ctx context.Context, artifact *models.Artifact)
 // FindWithLastPull ...
 func (s *artifactService) FindWithLastPull(ctx context.Context, repositoryID int64, before int64, limit, last int64) ([]*models.Artifact, error) {
 	return s.tx.Artifact.WithContext(ctx).
+		Where(s.tx.Artifact.ID.Gt(last), s.tx.Artifact.RepositoryID.Eq(repositoryID)).
 		Where(s.tx.Artifact.LastPull.Lt(before)).
 		Or(s.tx.Artifact.LastPull.IsNull(), s.tx.Artifact.UpdatedAt.Lt(before)).
-		Where(s.tx.Artifact.ID.Gt(last), s.tx.Artifact.RepositoryID.Eq(repositoryID)).
-		Limit(int(limit)).Find()
+		Limit(int(limit)).Order(s.tx.Artifact.ID).Find()
 }
 
 // FindAssociateWithTag ...

--- a/pkg/dal/dao/blob.go
+++ b/pkg/dal/dao/blob.go
@@ -88,7 +88,7 @@ func (s *blobService) FindWithLastPull(ctx context.Context, before int64, last, 
 		Where(s.tx.Blob.ID.Gt(last)).
 		Where(s.tx.Blob.LastPull.Lt(before)).
 		Or(s.tx.Blob.LastPull.IsNull(), s.tx.Blob.UpdatedAt.Lt(before)).
-		Find()
+		Order(s.tx.Blob.ID).Find()
 }
 
 // FindAssociateWithArtifact ...

--- a/pkg/dal/models/artifact.go
+++ b/pkg/dal/models/artifact.go
@@ -71,7 +71,7 @@ type ArtifactSizeByNamespaceOrRepository interface {
 
 // ArtifactAssociated ...
 type ArtifactAssociated interface {
-	// SELECT COUNT(artifact_id) as count FROM artifact_artifacts LEFT JOIN artifacts ON artifacts.id = artifact_artifacts.artifact_index_id WHERE artifacts.deleted_at = 0 AND artifact_index_id=@artifactID
+	// SELECT COUNT(artifact_id) as count FROM artifact_artifacts LEFT JOIN artifacts ON artifacts.id = artifact_artifacts.artifact_id WHERE artifacts.deleted_at = 0 AND artifact_index_id=@artifactID
 	ArtifactAssociated(artifactID int64) (gen.M, error)
 }
 

--- a/pkg/dal/query/artifacts.gen.go
+++ b/pkg/dal/query/artifacts.gen.go
@@ -1011,13 +1011,13 @@ func (a artifactDo) ArtifactSizeByRepository(repositoryID int64) (result models.
 	return
 }
 
-// SELECT COUNT(artifact_id) as count FROM artifact_artifacts LEFT JOIN artifacts ON artifacts.id = artifact_artifacts.artifact_index_id WHERE artifacts.deleted_at = 0 AND artifact_index_id=@artifactID
+// SELECT COUNT(artifact_id) as count FROM artifact_artifacts LEFT JOIN artifacts ON artifacts.id = artifact_artifacts.artifact_id WHERE artifacts.deleted_at = 0 AND artifact_index_id=@artifactID
 func (a artifactDo) ArtifactAssociated(artifactID int64) (result map[string]interface{}, err error) {
 	var params []interface{}
 
 	var generateSQL strings.Builder
 	params = append(params, artifactID)
-	generateSQL.WriteString("SELECT COUNT(artifact_id) as count FROM artifact_artifacts LEFT JOIN artifacts ON artifacts.id = artifact_artifacts.artifact_index_id WHERE artifacts.deleted_at = 0 AND artifact_index_id=? ")
+	generateSQL.WriteString("SELECT COUNT(artifact_id) as count FROM artifact_artifacts LEFT JOIN artifacts ON artifacts.id = artifact_artifacts.artifact_id WHERE artifacts.deleted_at = 0 AND artifact_index_id=? ")
 
 	result = make(map[string]interface{})
 	var executeSQL *gorm.DB


### PR DESCRIPTION
gc the multi-arch manifest need twice gc, first delete the manifest index and the referrer manifest, second delete the sub manifest