### PR TITLE
:sparkles: Check the redis config

### DIFF
--- a/pkg/modules/cacher/redis/redis.go
+++ b/pkg/modules/cacher/redis/redis.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-sigma/sigma/pkg/configs"
 	"github.com/go-sigma/sigma/pkg/modules/cacher/definition"
+	"github.com/go-sigma/sigma/pkg/types/enums"
 )
 
 type cacher[T any] struct {
@@ -35,6 +36,9 @@ type cacher[T any] struct {
 
 // New returns a new Cacher.
 func New[T any](config configs.Configuration, prefix string, fetcher definition.Fetcher[T]) (definition.Cacher[T], error) {
+	if config.Redis.Type != enums.RedisTypeExternal {
+		return nil, fmt.Errorf("cacher: please check redis configuration, it should be external")
+	}
 	redisOpt, err := redis.ParseURL(config.Redis.Url)
 	if err != nil {
 		return nil, err

--- a/pkg/modules/workq/redis/consumer.go
+++ b/pkg/modules/workq/redis/consumer.go
@@ -29,6 +29,9 @@ import (
 
 // NewWorkQueueConsumer ...
 func NewWorkQueueConsumer(config configs.Configuration, topicHandlers map[enums.Daemon]definition.Consumer) error {
+	if config.Redis.Type != enums.RedisTypeExternal {
+		return fmt.Errorf("work queue: please check redis configuration, it should be external")
+	}
 	redisOpt, err := asynq.ParseRedisURI(config.Redis.Url)
 	if err != nil {
 		return fmt.Errorf("asynq.ParseRedisURI error: %v", err)

--- a/pkg/modules/workq/redis/producer.go
+++ b/pkg/modules/workq/redis/producer.go
@@ -34,6 +34,9 @@ type producer struct {
 
 // NewWorkQueueProducer ...
 func NewWorkQueueProducer(config configs.Configuration, topicHandlers map[enums.Daemon]definition.Consumer) (definition.WorkQueueProducer, error) {
+	if config.Redis.Type != enums.RedisTypeExternal {
+		return nil, fmt.Errorf("work queue: please check redis configuration, it should be external")
+	}
 	redisOpt, err := asynq.ParseRedisURI(config.Redis.Url)
 	if err != nil {
 		return nil, fmt.Errorf("asynq.ParseRedisURI error: %v", err)


### PR DESCRIPTION
If `workqueue` use redis, the global redis type should be `external`:

``` yaml
redis:
  # redis type available: none, external
  # none: means never use redis
  # external: means use the specific redis instance
  type: external
  url: redis://:Admin@123@redis:6379/0

workqueue:
  # the workqueue type available: redis, kafka, database
  type: redis
  redis:
    concurrency: 10
  kafka: {}
  database: {}
```